### PR TITLE
Update README.md for Nephrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ To be listed here, the FOSS Obsidian clone must work with the Obsidian vault for
 - **[Cherit](https://github.com/Keshav-writes-code/Cherit)** → cross-platform, canvas planned
 - **[Mdit](https://github.com/hjinco/mdit)** → macOS-optimized, canvas and base planned
 - **[Foam](https://github.com/foambubble/foam)** → VS Code plugin, not cross-platform
+- **[Nephrite](https;//github.com/bithead2k/nephrite)** → cross platform, obsidian++, 7 plugins moved to core, mobile devices in planning
 
 [^5]: Only Excalidraw format for now, but using JSON Canvas as storage format is on the roadmap.
 


### PR DESCRIPTION
Nephrite is an Obsidian drop-in replacement.   It does everything Obsidian does, plus it moves many of the most popular plugins into the core.
Beyond being a clone, it offers a full vim editor, with a mostly complete vimscript.
Version 0.6.0 still relies on Obsidian sync.   That may change in the near future.